### PR TITLE
fix issue #120 - use take() to correctly limit the entities returned

### DIFF
--- a/src/modules/api/shoutouts/shoutouts.service.ts
+++ b/src/modules/api/shoutouts/shoutouts.service.ts
@@ -17,7 +17,7 @@ export class ShoutoutsService {
     const shoutouts: ShoutoutDto[] = await this.helperService
       .getShoutouts()
       .orderBy('shoutout.createDate', 'DESC')
-      .limit(LATEST_SHOUTOUTS_LIMIT)
+      .take(LATEST_SHOUTOUTS_LIMIT)
       .getMany();
 
     await this.helperService.postProcessShoutouts(shoutouts);


### PR DESCRIPTION
fix for #120 

Change /latest api query to use `take()`.  `limit()` seemed to limit rows on a table which affected the joined `elements` table and which the documentation warns about.  So the rows from `elements` was being limited incorrectly.